### PR TITLE
Add savings dashboard prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Tabungan
+# Tabungan Bersama Prototype
+
+Prototype dashboard tabungan bersama untuk dua pengguna dengan modul "Nabung Rutin Perminggu".
+
+## Cara Menjalankan
+
+Buka file `index.html` langsung di browser favorit Anda. Semua gaya dan data dummy sudah dimuat lewat `styles.css` dan `app.js`.
+
+## Fitur Utama
+
+- Ringkasan target tabungan bersama dengan progress bar.
+- Status target mingguan lengkap dengan notifikasi otomatis sesuai kontribusi User A (Egi) dan User B (Partner).
+- Kartu per pengguna yang menampilkan avatar, target, dan status setoran mingguan.
+- Tabel riwayat setoran mingguan.
+- Grafik batang kontribusi 8 minggu terakhir dan informasi streak.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,213 @@
+const savingsData = {
+  goalTitle: 'Liburan Bali Rp 5.000.000',
+  goalAmount: 5000000,
+  totalSaved: 2650000,
+  weeklyTarget: 200000,
+  users: [
+    {
+      id: 'a',
+      name: 'Egi',
+      avatar: '🧑🏻',
+      color: '#377dff',
+      weeklyTarget: 100000,
+      contributionThisWeek: 100000,
+      hasPaid: true
+    },
+    {
+      id: 'b',
+      name: 'Partner',
+      avatar: '🧑🏽',
+      color: '#34c759',
+      weeklyTarget: 100000,
+      contributionThisWeek: 0,
+      hasPaid: false
+    }
+  ],
+  history: [
+    { date: '08 Okt', name: 'Egi', amount: 100000, status: '✅' },
+    { date: '02 Okt', name: 'Partner', amount: 100000, status: '✅' },
+    { date: '01 Okt', name: 'Egi', amount: 100000, status: '✅' },
+    { date: '24 Sep', name: 'Partner', amount: 100000, status: '✅' }
+  ],
+  weeklyBreakdown: [
+    { label: 'M-7', a: 100000, b: 90000 },
+    { label: 'M-6', a: 100000, b: 100000 },
+    { label: 'M-5', a: 80000, b: 100000 },
+    { label: 'M-4', a: 100000, b: 100000 },
+    { label: 'M-3', a: 100000, b: 70000 },
+    { label: 'M-2', a: 100000, b: 100000 },
+    { label: 'M-1', a: 100000, b: 100000 },
+    { label: 'Minggu Ini', a: 100000, b: 0 }
+  ],
+  streakWeeks: 3
+};
+
+function formatCurrency(amount) {
+  return new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    maximumFractionDigits: 0
+  }).format(amount);
+}
+
+function updateGoalProgress({ goalTitle, goalAmount, totalSaved }) {
+  const titleEl = document.getElementById('goal-title');
+  const progressValueEl = document.getElementById('goal-progress-value');
+  const progressBarEl = document.getElementById('goal-progress-bar');
+
+  titleEl.textContent = goalTitle;
+  progressValueEl.textContent = `${formatCurrency(totalSaved)} dari ${formatCurrency(goalAmount)}`;
+
+  const percent = Math.min((totalSaved / goalAmount) * 100, 100);
+  progressBarEl.style.width = `${percent}%`;
+  progressBarEl.setAttribute('aria-valuenow', percent.toFixed(1));
+}
+
+function renderUserCards(users) {
+  const container = document.getElementById('user-cards');
+  container.innerHTML = '';
+
+  users.forEach((user) => {
+    const card = document.createElement('article');
+    card.className = `user-card user-card--${user.id}`;
+
+    const header = document.createElement('div');
+    header.className = 'user-card__header';
+
+    const avatar = document.createElement('div');
+    avatar.className = `avatar avatar--${user.id}`;
+    avatar.style.background = user.color;
+    avatar.textContent = user.avatar;
+
+    const titleWrap = document.createElement('div');
+    const nameEl = document.createElement('div');
+    nameEl.className = 'user-card__name';
+    nameEl.textContent = user.name;
+
+    const targetEl = document.createElement('div');
+    targetEl.className = 'user-card__target';
+    targetEl.textContent = `Target: ${formatCurrency(user.weeklyTarget)}`;
+
+    titleWrap.append(nameEl, targetEl);
+    header.append(avatar, titleWrap);
+
+    const status = document.createElement('div');
+    status.className = 'user-card__status';
+    status.classList.toggle('user-card__status--done', user.hasPaid);
+    status.innerHTML = `${user.hasPaid ? '✅' : '❌'} ${user.hasPaid ? 'Sudah Setor' : 'Belum Setor'}`;
+
+    const contribution = document.createElement('div');
+    contribution.className = 'user-card__target';
+    contribution.textContent = `Realisasi: ${formatCurrency(user.contributionThisWeek)}`;
+
+    card.append(header, status, contribution);
+    container.appendChild(card);
+  });
+}
+
+function renderHistory(history) {
+  const tbody = document.getElementById('history-body');
+  tbody.innerHTML = '';
+
+  history.forEach((item) => {
+    const row = document.createElement('tr');
+
+    row.innerHTML = `
+      <td>${item.date}</td>
+      <td>${item.name}</td>
+      <td>${formatCurrency(item.amount)}</td>
+      <td>
+        <span class="status-dot ${item.status === '✅' ? 'status-dot--done' : 'status-dot--pending'}"></span>
+        ${item.status}
+      </td>
+    `;
+
+    tbody.appendChild(row);
+  });
+}
+
+function renderWeeklyTarget(weeklyTarget, users) {
+  const label = document.getElementById('weekly-target-label');
+  const statusPill = document.getElementById('weekly-target-status');
+  const icon = statusPill.querySelector('.status-pill__icon');
+  const text = statusPill.querySelector('.status-pill__text');
+
+  const totalThisWeek = users.reduce((sum, user) => sum + user.contributionThisWeek, 0);
+  const isDone = totalThisWeek >= weeklyTarget;
+
+  label.textContent = formatCurrency(weeklyTarget);
+
+  statusPill.classList.remove('status-pill--done', 'status-pill--pending');
+  statusPill.classList.add(isDone ? 'status-pill--done' : 'status-pill--pending');
+  icon.textContent = isDone ? '✅' : '❌';
+  text.textContent = isDone ? 'Done' : 'Belum';
+}
+
+function renderWeeklyChart(breakdown, users) {
+  const chart = document.getElementById('weekly-chart');
+  chart.innerHTML = '';
+  const maxAmount = Math.max(...breakdown.map((item) => Math.max(item.a, item.b))) || 1;
+
+  breakdown.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'chart__row';
+
+    const label = document.createElement('div');
+    label.className = 'chart__label';
+    label.textContent = item.label;
+
+    const bars = document.createElement('div');
+    bars.className = 'chart__bars';
+
+    const barA = document.createElement('div');
+    barA.className = 'chart__bar chart__bar--a';
+    barA.style.setProperty('--value', `${(item.a / maxAmount) * 100}%`);
+
+    const barB = document.createElement('div');
+    barB.className = 'chart__bar chart__bar--b';
+    barB.style.setProperty('--value', `${(item.b / maxAmount) * 100}%`);
+
+    const value = document.createElement('div');
+    value.className = 'chart__bar-value';
+    value.textContent = `${formatCurrency(item.a)} • ${formatCurrency(item.b)}`;
+
+    bars.append(barA, barB);
+    row.append(label, bars, value);
+    chart.appendChild(row);
+  });
+}
+
+function renderNotification(users, weeklyTarget) {
+  const notification = document.getElementById('notification');
+  const [userA, userB] = users;
+  const totalThisWeek = users.reduce((sum, user) => sum + user.contributionThisWeek, 0);
+
+  if (userA.hasPaid && userB.hasPaid) {
+    notification.textContent = 'Mantap! Minggu ini kompak menabung 🎉.';
+  } else if (userA.hasPaid && !userB.hasPaid) {
+    const remaining = weeklyTarget - totalThisWeek;
+    notification.textContent = `${userA.name} sudah setor ${formatCurrency(userA.contributionThisWeek)}. Yuk ${userB.name}, tinggal ${formatCurrency(remaining)} lagi minggu ini!`;
+  } else if (!userA.hasPaid && userB.hasPaid) {
+    const remaining = weeklyTarget - totalThisWeek;
+    notification.textContent = `${userB.name} sudah setor ${formatCurrency(userB.contributionThisWeek)}. Yuk ${userA.name}, tinggal ${formatCurrency(remaining)} lagi minggu ini!`;
+  } else {
+    notification.textContent = 'Belum ada setoran minggu ini, semangat mulai dari kamu duluan!';
+  }
+}
+
+function renderStreak(streakWeeks) {
+  const streak = document.getElementById('streak-message');
+  streak.textContent = `Sudah ${streakWeeks} minggu berturut-turut kompak ✅`;
+}
+
+function initDashboard() {
+  updateGoalProgress(savingsData);
+  renderUserCards(savingsData.users);
+  renderHistory(savingsData.history);
+  renderWeeklyTarget(savingsData.weeklyTarget, savingsData.users);
+  renderWeeklyChart(savingsData.weeklyBreakdown, savingsData.users);
+  renderNotification(savingsData.users, savingsData.weeklyTarget);
+  renderStreak(savingsData.streakWeeks);
+}
+
+window.addEventListener('DOMContentLoaded', initDashboard);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="id">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tabungan Bersama</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <header class="hero">
+        <div class="hero__title">
+          <div class="hero__label">🎯 Target Tabungan</div>
+          <h1 id="goal-title">Liburan Bali Rp 5.000.000</h1>
+        </div>
+        <div class="hero__progress">
+          <div class="hero__progress-info">
+            <span id="goal-progress-label">Progress Terkumpul</span>
+            <span id="goal-progress-value" class="hero__progress-value"></span>
+          </div>
+          <div class="progress-bar">
+            <div class="progress-bar__fill" id="goal-progress-bar"></div>
+          </div>
+        </div>
+        <div class="hero__week-card">
+          <div>
+            <h2>Target Minggu Ini</h2>
+            <p id="weekly-target-label">Rp 200.000</p>
+          </div>
+          <div class="status-pill" id="weekly-target-status">
+            <span class="status-pill__icon">❌</span>
+            <span class="status-pill__text">Belum</span>
+          </div>
+        </div>
+        <div class="notification" id="notification"></div>
+      </header>
+
+      <main class="main-grid">
+        <section class="user-cards" id="user-cards"></section>
+
+        <section class="history">
+          <div class="section-header">
+            <div>
+              <h2>Riwayat Minggu Ini</h2>
+              <p>Setoran terbaru untuk target rutin perminggu</p>
+            </div>
+            <div class="history__legend">
+              <span class="legend-item">
+                <span class="legend-dot legend-dot--a"></span> Egi
+              </span>
+              <span class="legend-item">
+                <span class="legend-dot legend-dot--b"></span> Partner
+              </span>
+            </div>
+          </div>
+          <div class="table-wrapper">
+            <table>
+              <thead>
+                <tr>
+                  <th>Tanggal</th>
+                  <th>Nama</th>
+                  <th>Nominal</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody id="history-body"></tbody>
+            </table>
+          </div>
+        </section>
+
+        <section class="weekly-progress">
+          <div class="section-header">
+            <div>
+              <h2>Detail Progress Mingguan</h2>
+              <p>Performa 8 minggu terakhir</p>
+            </div>
+          </div>
+          <div class="chart" id="weekly-chart"></div>
+          <div class="streak" id="streak-message">
+            Sudah 3 minggu berturut-turut kompak ✅
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,467 @@
+:root {
+  --blue: #377dff;
+  --blue-soft: rgba(55, 125, 255, 0.12);
+  --green: #34c759;
+  --green-soft: rgba(52, 199, 89, 0.12);
+  --purple: #a855f7;
+  --bg: #f7f9fc;
+  --card-bg: #ffffff;
+  --text-main: #1f2937;
+  --text-muted: #6b7280;
+  --border: #e5e7eb;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text-main);
+  font-family: 'Poppins', system-ui;
+  line-height: 1.6;
+  padding: 2.5rem 1rem 4rem;
+}
+
+.app {
+  max-width: 1120px;
+  margin: 0 auto;
+  display: grid;
+  gap: 2.5rem;
+}
+
+.hero {
+  background: linear-gradient(135deg, rgba(55, 125, 255, 0.12), rgba(52, 199, 89, 0.12));
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  padding: 2.5rem;
+  display: grid;
+  gap: 1.75rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: '🤝';
+  position: absolute;
+  font-size: 6.5rem;
+  right: 2.5rem;
+  bottom: -1.5rem;
+  opacity: 0.15;
+}
+
+.hero__title h1 {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--text-main);
+}
+
+.hero__label {
+  background: var(--card-bg);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--blue);
+  border: 1px solid rgba(55, 125, 255, 0.15);
+  box-shadow: 0 10px 30px rgba(55, 125, 255, 0.08);
+}
+
+.hero__progress {
+  display: grid;
+  gap: 1rem;
+}
+
+.hero__progress-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.hero__progress-value {
+  font-size: 1.45rem;
+  color: var(--text-main);
+}
+
+.progress-bar {
+  height: 16px;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(55, 125, 255, 0.12);
+  overflow: hidden;
+  position: relative;
+}
+
+.progress-bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--blue), var(--green));
+  width: 0;
+  border-radius: inherit;
+  transition: width 0.6s ease-in-out;
+}
+
+.hero__week-card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.5rem 1.75rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.hero__week-card h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.hero__week-card p {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: all 0.3s ease;
+}
+
+.status-pill--done {
+  background: var(--green-soft);
+  color: var(--green);
+  border-color: rgba(52, 199, 89, 0.35);
+}
+
+.status-pill--pending {
+  background: rgba(248, 113, 113, 0.12);
+  color: #f87171;
+  border-color: rgba(248, 113, 113, 0.35);
+}
+
+.notification {
+  background: var(--card-bg);
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  border: 1px solid rgba(55, 125, 255, 0.15);
+  box-shadow: 0 10px 30px rgba(55, 125, 255, 0.08);
+  font-weight: 500;
+  color: var(--text-main);
+}
+
+.notification::before {
+  content: '💌';
+  font-size: 1.5rem;
+}
+
+.main-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.user-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+}
+
+.user-card {
+  background: var(--card-bg);
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.2rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+
+.user-card::after {
+  content: '';
+  position: absolute;
+  top: -40px;
+  right: -40px;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: rgba(55, 125, 255, 0.08);
+  transition: transform 0.3s ease;
+}
+
+.user-card--b::after {
+  background: rgba(52, 199, 89, 0.12);
+}
+
+.user-card:hover::after {
+  transform: scale(1.1);
+}
+
+.user-card__header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--card-bg);
+}
+
+.avatar--a {
+  background: var(--blue);
+}
+
+.avatar--b {
+  background: var(--green);
+}
+
+.user-card__name {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.user-card__target {
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.user-card__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+.user-card__status--done {
+  background: var(--green-soft);
+  color: var(--green);
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.section-header p {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.history {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.05);
+}
+
+.history__legend {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.legend-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.legend-dot--a {
+  background: var(--blue);
+}
+
+.legend-dot--b {
+  background: var(--green);
+}
+
+.table-wrapper {
+  margin-top: 1.25rem;
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead {
+  background: rgba(55, 125, 255, 0.08);
+}
+
+thead th {
+  text-align: left;
+  padding: 0.75rem 0.9rem;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+tbody td {
+  padding: 0.75rem 0.9rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.status-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: 0.5rem;
+}
+
+.status-dot--done {
+  background: var(--green);
+}
+
+.status-dot--pending {
+  background: #f87171;
+}
+
+.weekly-progress {
+  background: var(--card-bg);
+  border-radius: 20px;
+  padding: 1.75rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.05);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.chart {
+  display: grid;
+  gap: 0.9rem;
+}
+
+.chart__row {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.chart__label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.chart__bars {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.chart__bar {
+  height: 18px;
+  border-radius: 999px;
+  position: relative;
+  overflow: hidden;
+  flex: 1;
+  background: rgba(55, 125, 255, 0.08);
+}
+
+.chart__bar::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: var(--value, 0%);
+  border-radius: inherit;
+}
+
+.chart__bar--a::after {
+  background: var(--blue);
+}
+
+.chart__bar--b::after {
+  background: var(--green);
+}
+
+.chart__bar-value {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.streak {
+  background: linear-gradient(90deg, rgba(55, 125, 255, 0.12), rgba(52, 199, 89, 0.12));
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  font-weight: 600;
+  color: var(--text-main);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.streak::before {
+  content: '🔥';
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .hero {
+    padding: 2rem 1.5rem;
+  }
+
+  .hero__title h1 {
+    font-size: 1.75rem;
+  }
+
+  .hero__week-card {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- build a single-page shared savings dashboard layout covering weekly goals, user cards, history, and progress sections
- style the experience with a playful collaborative theme, distinct colors per user, and responsive layouts
- script dummy savings data to populate progress, statuses, notifications, and weekly bar chart

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68de9ddcfe58832ea4b61d2f48e0cae1